### PR TITLE
Enh: Add supported file extensions

### DIFF
--- a/controllers/EditController.php
+++ b/controllers/EditController.php
@@ -38,10 +38,12 @@ class EditController extends BaseFileController
             }
         }
 
+        $mimeType = $file->mime_type;
+        
         return $this->renderAjax('index', [
             'fileUpdate' => $fileUpdate,
             'file' => $file,
+            'mimeType' => $mimeType,
         ]);
     }
-
 }

--- a/controllers/ViewController.php
+++ b/controllers/ViewController.php
@@ -8,6 +8,7 @@
 namespace humhub\modules\text_editor\controllers;
 
 use humhub\modules\text_editor\components\BaseFileController;
+use humhub\modules\text_editor\models\CreateFile;
 use Yii;
 use yii\web\HttpException;
 
@@ -27,13 +28,25 @@ class ViewController extends BaseFileController
             throw new HttpException(401, Yii::t('TextEditorModule.base', 'Insufficient permissions!'));
         }
 
-        if (!is_readable($file->getStore()->get())) {
+        $filePath = $file->getStore()->get();
+        if (!is_readable($filePath)) {
             throw new HttpException(403, Yii::t('TextEditorModule.base', 'File is not readable!'));
         }
 
+        $mimeType = $file->mime_type;
+
+        if ($mimeType == 'application/xml') {
+            Yii::$app->response->format = \yii\web\Response::FORMAT_XML;
+        } else {
+            Yii::$app->response->format = \yii\web\Response::FORMAT_RAW;
+        }
+
+        $fileContent = file_get_contents($filePath);
+
         return $this->renderAjax('index', [
             'file' => $file,
+            'fileContent' => $fileContent,
+            'mimeType' => $mimeType,
         ]);
     }
-
 }

--- a/models/CreateFile.php
+++ b/models/CreateFile.php
@@ -12,7 +12,7 @@ use Yii;
 use yii\base\Model;
 
 /**
- * CreateFile is a form for create a new text file
+ * CreateFile is a form for creating new text-based files (Text, Log, XML)
  *
  * @author Luke
  */
@@ -24,9 +24,32 @@ class CreateFile extends Model
     public $fileName;
 
     /**
+     * @var string
+     */
+    public $fileType;
+
+    /**
      * @var bool
      */
     public $openEditForm = true;
+
+    /**
+     * Supported file types and their corresponding MIME types
+     */
+    const SUPPORTED_TYPES = [
+        'text' => 'text/plain',
+        'log' => 'text/plain',
+        'xml' => 'application/xml'
+    ];
+
+    /**
+     * Supported file extensions
+     */
+    const FILE_EXTENSIONS = [
+        'text' => '.txt',
+        'log' => '.log',
+        'xml' => '.xml'
+    ];
 
     /**
      * @inheritdoc
@@ -36,8 +59,43 @@ class CreateFile extends Model
         return [
             ['fileName', 'required'],
             ['fileName', 'string', 'max' => 255],
+            ['fileName', 'validateFileName'],
+            ['fileType', 'required'],
+            ['fileType', 'in', 'range' => array_keys(self::SUPPORTED_TYPES)],
             ['openEditForm', 'boolean'],
         ];
+    }
+
+    /**
+     * Validates the file name and ensures proper extension
+     */
+    public function validateFileName($attribute, $params)
+    {
+        if (!$this->hasErrors()) {
+            $extension = $this->getFileExtension($this->fileName);
+            $expectedExtension = self::FILE_EXTENSIONS[$this->fileType];
+
+            if ($extension && $extension !== $expectedExtension) {
+                $this->addError($attribute, Yii::t('TextEditorModule.base', 
+                    'Invalid file extension. Expected {expected} for {type} files.', 
+                    ['expected' => $expectedExtension, 'type' => $this->fileType]
+                ));
+            } elseif (!$extension) {
+                // Automatically append the correct extension if none provided
+                $this->fileName .= $expectedExtension;
+            }
+        }
+    }
+
+    /**
+     * Gets the file extension from a filename
+     * @param string $fileName
+     * @return string|null
+     */
+    protected function getFileExtension($fileName)
+    {
+        $lastDot = strrpos($fileName, '.');
+        return $lastDot === false ? null : strtolower(substr($fileName, $lastDot));
     }
 
     /**
@@ -46,11 +104,26 @@ class CreateFile extends Model
     public function attributeLabels()
     {
         return [
+            'fileName' => Yii::t('TextEditorModule.base', 'File Name'),
+            'fileType' => Yii::t('TextEditorModule.base', 'File Type'),
             'openEditForm' => Yii::t('TextEditorModule.base', 'Edit the new file in the next step'),
         ];
     }
 
     /**
+     * @return array
+     */
+    public function getFileTypeOptions()
+    {
+        return [
+            'text' => Yii::t('TextEditorModule.base', 'Text File (.txt)'),
+            'log' => Yii::t('TextEditorModule.base', 'Log File (.log)'),
+            'xml' => Yii::t('TextEditorModule.base', 'XML File (.xml)'),
+        ];
+    }
+
+    /**
+     * Creates a new file with the specified type
      * @return false|File
      */
     public function save()
@@ -62,14 +135,18 @@ class CreateFile extends Model
         $file = new File();
         $file->file_name = $this->fileName;
         $file->size = 0;
-        $file->mime_type = 'text/plain';
+        $file->mime_type = self::SUPPORTED_TYPES[$this->fileType];
+
         if (!$file->save()) {
             return false;
         }
 
-        $file->store->setContent('');
+        // Add XML declaration if creating an XML file
+        $initialContent = $this->fileType === 'xml' 
+            ? '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<root></root>'
+            : '';
 
+        $file->store->setContent($initialContent);
         return $file;
     }
-
 }

--- a/views/create/index.php
+++ b/views/create/index.php
@@ -24,6 +24,7 @@ Assets::register($this);
 
     <div class="modal-body">
         <?= $form->field($model, 'fileName')->textInput(['autofocus' => '']) ?>
+        <?= $form->field($model, 'fileType')->dropDownList($fileTypeOptions, ['placeholder' => Yii::t('TextEditorModule.base', 'Select file type...')]) ?>
         <?= $form->field($model, 'openEditForm')->checkbox() ?>
     </div>
 

--- a/views/edit/index.php
+++ b/views/edit/index.php
@@ -15,6 +15,7 @@ use humhub\widgets\ModalDialog;
 
 /* @var $fileUpdate FileUpdate */
 /* @var $file \humhub\modules\file\models\File */
+/* @var $mimeType string */
 
 Assets::register($this);
 ?>
@@ -28,7 +29,6 @@ Assets::register($this);
         <?php $form = ActiveForm::begin(['method' => 'post', 'acknowledge' => true]) ?>
         <div class="modal-body">
             <?= $form->field($fileUpdate, 'newFileContent')->widget(CodeMirrorInputWidget::class)->label(false) ?>
-
             <div class="clearfix"></div>
         </div>
 

--- a/views/view/index.php
+++ b/views/view/index.php
@@ -11,14 +11,15 @@ use humhub\widgets\ModalButton;
 use humhub\widgets\ModalDialog;
 
 /* @var $file File */
+/* @var $fileContent string */
 ?>
 
 <?php ModalDialog::begin([
-        'header' => Yii::t('TextEditorModule.base', '<strong>View file:</strong>  {fileName}', ['fileName' => Html::encode($file->file_name)]),
-        'options' => ['style' => 'width:95%'],
-    ]) ?>
+    'header' => Yii::t('TextEditorModule.base', '<strong>View file:</strong>  {fileName}', ['fileName' => Html::encode($file->file_name)]),
+    'options' => ['style' => 'width:95%'],
+]) ?>
     <div class="modal-body">
-        <pre><?= htmlentities(file_get_contents($file->getStore()->get())) ?></pre>
+        <pre><?= htmlentities($fileContent, ENT_QUOTES, 'UTF-8') ?></pre>
         <div class="clearfix"></div>
     </div>
 


### PR DESCRIPTION
I'd like to note that I have not found a way to enable editing of the xml files as of yet for this current version, but I believe this should help users when it comes to picking between the three supported file formats, it also automatically applies the correct file extension on save.

### Create Form
![Screenshot_1](https://github.com/user-attachments/assets/ace0e8ab-a4f6-4466-b8e7-26e0d41f5010)

### Create `.txt`
![Screenshot_2](https://github.com/user-attachments/assets/a5414cef-2380-4a16-b137-21754bc73211)

### Create `.xml`
![Screenshot_3](https://github.com/user-attachments/assets/b8f132bc-019c-4574-bdc5-f9752c4ed2da)

### Create `.log`
![Screenshot_6](https://github.com/user-attachments/assets/e180ea07-58e4-4b45-8064-ed42289c4245)

### After saving
![Screenshot_4](https://github.com/user-attachments/assets/cd7100df-0301-480a-89dc-bc197aee5bbd)

### Saved `.txt`
![Screenshot_5](https://github.com/user-attachments/assets/cf454206-e89b-40cc-8c3d-ff868d53a406)

### Saved `.log`
![Screenshot_7](https://github.com/user-attachments/assets/8f0326db-fb0d-49e1-a79b-5df2768fb26e)
